### PR TITLE
add data folder to repo so we can use csv command again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,6 @@ cython_debug/
 
 # data dir
 data/*
+!data/.gitkeep 
 
 .vscode/


### PR DESCRIPTION
`$csv` command stopped working and it seems the reason is because we ignore the entire `data/` folder.
updated `.gitignore` so we can keep the folder but still ignore the files within it.
can't add empty folders so created the `.gitkeep` file within the `data/` folder.