### PR TITLE
Disable BTC Pizza Day Event until time logic is refactored

### DIFF
--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -8,7 +8,7 @@ from constants import ANNOUNCEMENTS_CHAN_ID
 logger = logging.getLogger(__name__)
 
 EVENTS = [
-    PizzaDaoEvent(5, 22,  "Bitcoin Pizza Day"),
+    PizzaDaoEvent(5, 22,  "Bitcoin Pizza Day", False),
     PizzaDaoEvent(6, 28, "Tau Day", False),
     PizzaDaoEvent(11, 2, "NFT.NYC 2021 Drop", False) # TODO - add exp date for one-off events or just update code and delete this line after event
 ]


### PR DESCRIPTION
Date does not reset and thus it gets stuck on the day the bot was restarted. Disabling all events until time logic is fixed